### PR TITLE
KAS-4883 refactor job status, job model predicates, fix inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Users of this service should have `:read`, `:write` and `:read-for-write` access
   match: {
     predicate: {
       type: 'uri',
-      value: 'http://mu.semte.ch/vocabularies/ext/status'
+      value: 'http://www.w3.org/ns/adms#status'
     },
     object: {
       type: 'uri'
@@ -90,24 +90,40 @@ Users of this service should have `:read`, `:write` and `:read-for-write` access
 (define-resource file-bundling-job ()
   :class (s-prefix "ext:FileBundlingJob") ; "cogs:Job"
   :properties `((:created       :datetime  ,(s-prefix "dct:created"))
-                (:status        :uri       ,(s-prefix "ext:status"))
+                (:status        :uri       ,(s-prefix "adms:status"))
                 (:time-started  :datetime  ,(s-prefix "prov:startedAtTime"))
                 (:time-ended    :datetime  ,(s-prefix "prov:endedAtTime"))
+                (:message       :string    ,(s-prefix "schema:error"))
   )
   :has-one `((file              :via     ,(s-prefix "prov:generated")
                                 :as "generated"))
-  ; :resource-base (s-url "http://example.com/id/file-bundling-jobs/")
+  ; :resource-base (s-url "http://mu.semte.ch/services/file-bundling-service/file-bundling-jobs/")
   :features '(include-uri)
   :on-path "file-bundling-jobs"
 )
+
+;; Not strictly necessary if not used
+(define-resource collection ()
+  :class (s-prefix "prov:Collection")
+  :properties `((:sha256        :string  ,(s-prefix "ext:sha256")))
+  :has-one `((file-bundling-job :via     ,(s-prefix "prov:used")
+                                :inverse t
+                                :as "file-bundling-job"))
+  :has-many `((file             :via     ,(s-prefix "prov:hadMember")
+                                :as "members"))
+  ; :resource-base (s-url "http://mu.semte.ch/services/file-bundling-service/collections/")
+  :features '(include-uri)
+  :on-path "collections")
 ```
 
 `repository.lisp`:
 ```lisp
 (add-prefix "ext" "http://mu.semte.ch/vocabularies/ext/")
+(add-prefix "adms" "http://www.w3.org/ns/adms#")
 (add-prefix "dct" "http://purl.org/dc/terms/")
 (add-prefix "prov" "http://www.w3.org/ns/prov#")
 (add-prefix "cogs" "http://vocab.deri.ie/cogs#")
+(add-prefix "schema" "http://schema.org/")
 ```
 
 `dispatcher.ex`:
@@ -154,8 +170,11 @@ On successful creation of a job.
     "id": "5f680870-5984-11ea-98be-11315490e00b",
     "attributes": {
       "uri": "http://mu.semte.ch/services/file-bundling-service/file-bundling-jobs/5f680870-5984-11ea-98be-11315490e00b",
-      "status": "http://vocab.deri.ie/cogs#Running",
-      "created": "2020-02-27T17:12:45.943Z"
+      "status": "http://redpencil.data.gift/id/concept/JobStatus/busy",
+      "created": "2020-02-27T17:12:45.943Z",
+      "time-started": "2020-02-27T17:13:45.943Z",
+      "time-ended": "2020-02-27T17:15:45.943Z",
+      "message": "The error message we got if the job failed"
     }
   }
 }
@@ -171,7 +190,7 @@ When an archive for the exact set of requested files *already is available*, the
     "id": "5f680870-5984-11ea-98be-11315490e00b",
     "attributes": {
       "uri": "http://mu.semte.ch/services/file-bundling-service/file-bundling-jobs/5f680870-5984-11ea-98be-11315490e00b",
-      "status": "http://vocab.deri.ie/cogs#Success",
+      "status": "http://redpencil.data.gift/id/concept/JobStatus/success",
       "created": "2020-02-27T17:12:45.943Z"
     },
     "relationships": {

--- a/app.js
+++ b/app.js
@@ -5,18 +5,21 @@ import { getFilesById, getFile } from './queries/file';
 import { runBundlingJob as bundlingJobRunner } from './lib/bundling-job';
 import { runJob as jobRunner } from './lib/job';
 import { findCollectionByMembers, createCollection } from './queries/collection';
-import { createJob, findJobUsingCollection, attachCollectionToJob, findAllJobArchives } from './queries/job';
+import { createJob, findJobUsingCollection, attachCollectionToJob, findAllJobArchives, updateJobStatus } from './queries/job';
 import { removeJobAndCollection } from "./queries/delta";
 import {
   filterDeltaForDeletedFiles, handleFileDeletions,
   filterDeltaForCreatedJobs, filterDeltaForStatusChangedJobs
 } from './lib/delta';
 import { verifyArchive } from './lib/archive';
+import { JOB } from './config';
 
 /*
  * TODO: Javascript template body parser only allows up to 100kb of payload size (https://github.com/expressjs/body-parser#limit).
  * This is insufficiënt when sending archiving requests for many files
  */
+// TODO This entire API endpoint is not actively used, job-creation does this for each archive now. remove for clarity?
+// TODO we could then also consolidate both services into 1?
 app.post('/files/archive', findJob, sendJob, runJob);
 
 async function findJob (req, res, next) {
@@ -28,12 +31,16 @@ async function findJob (req, res, next) {
     job = await findJobUsingCollection(collection.uri);
   }
   if (job) {
+    // ! TODO see above, this endpoint is unused and therefore untested
+    // If this is kept, what happens when a job is created but the creation of the collection fails?
     job.generated = await getFile(job.generated);
     res.status(200);
   } else {
     job = await createJob();
     const fileCollection = await createCollection(req.authorizedFiles);
     await attachCollectionToJob(job.uri, fileCollection.uri);
+    await updateJobStatus(job.uri, JOB.STATUSES.SCHEDULED);
+    job = await findJobUsingCollection(collection.uri); // new metadata after setting status
     res.status(201);
   }
   res.job = job;
@@ -43,12 +50,15 @@ async function findJob (req, res, next) {
 async function sendJob (req, res, next) {
   const payload = {};
   payload.data = {
-    type: 'file-bundling-jobs',
+    type: JOB.JSONAPI_JOB_TYPE,
     id: res.job.id,
     attributes: {
       uri: res.job.uri,
       status: res.job.status,
-      created: res.job.created
+      created: res.job.created,
+      "time-started": res.job.started,
+      "time-ended": res.job.ended,
+      message: res.job.message
     }
   };
   if (res.statusCode === 200) {

--- a/config.js
+++ b/config.js
@@ -7,10 +7,19 @@ if (!STORAGE_PATH.endsWith('/')) {
   STORAGE_PATH = `${STORAGE_PATH}/`;
 }
 
-const RDF_JOB_TYPE = 'http://mu.semte.ch/vocabularies/ext/FileBundlingJob';
+const JOB = {
+  STATUSES: {
+    SCHEDULED: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled',
+    BUSY: 'http://redpencil.data.gift/id/concept/JobStatus/busy',
+    SUCCESS: 'http://redpencil.data.gift/id/concept/JobStatus/success',
+    FAILED: 'http://redpencil.data.gift/id/concept/JobStatus/failed',
+  },
+  RDF_TYPE: 'http://mu.semte.ch/vocabularies/ext/FileBundlingJob',
+  JSONAPI_JOB_TYPE: 'file-bundling-jobs',
+};
 
 module.exports = {
   RESOURCE_BASE,
   STORAGE_PATH,
-  RDF_JOB_TYPE
+  JOB
 };

--- a/lib/delta.js
+++ b/lib/delta.js
@@ -5,7 +5,7 @@ import {
   removeJobAndCollection,
   findJobsWithoutCollectionMembers,
 } from "../queries/delta";
-import { RDF_JOB_TYPE } from "../config";
+import { JOB } from "../config";
 
 // TODO file insert does not always invalidate current zip (for example adding a file as admin after archiving) 
 function filterDeltaForDeletedFiles (deltaBody) {
@@ -41,7 +41,7 @@ function filterDeltaForCreatedJobs (deltaBody) {
   if (insertionDeltas) {
     const insertedJobs = insertionDeltas.filter(delta => {
       return delta.predicate.value === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' &&
-        delta.object.value === RDF_JOB_TYPE;
+        delta.object.value === JOB.RDF_TYPE;
     }).map(delta => delta.subject.value);
     return insertedJobs;
   }
@@ -51,7 +51,7 @@ function filterDeltaForStatusChangedJobs (deltaBody) {
   const deletionDeltas = deltaBody.map(d => d.deletes).reduce((ds, d) => Array.prototype.concat.apply(ds, d));
   if (deletionDeltas) {
     const changedStatusJobs = deletionDeltas.filter(delta => {
-      return delta.predicate.value === 'http://mu.semte.ch/vocabularies/ext/status';
+      return delta.predicate.value === 'http://www.w3.org/ns/adms#status';
     }).map(delta => delta.subject.value);
     return changedStatusJobs;
   }

--- a/lib/job.js
+++ b/lib/job.js
@@ -1,20 +1,20 @@
-import {
-  RUNNING, SUCCESS, FAIL, updateJobStatus, findJobTodo
-} from '../queries/job';
+import { updateJobStatus, findScheduledJob } from '../queries/job';
+import { JOB } from '../config'
 
 async function runJob (jobUri, runner) {
-  const job = await findJobTodo(jobUri);
+  const job = await findScheduledJob(jobUri);
   if (!job) {
-    console.log(`No job TODO found by uri <${jobUri}>`);
+    console.log(`No job SCHEDULED found by uri <${jobUri}>`);
     return;
   }
-  await updateJobStatus(job.uri, RUNNING);
+  await updateJobStatus(job.uri, JOB.STATUSES.BUSY);
   try {
     await runner(job);
-    await updateJobStatus(job.uri, SUCCESS);
+    await updateJobStatus(job.uri, JOB.STATUSES.SUCCESS);
   } catch (e) {
-    console.log(e);
-    await updateJobStatus(job.uri, FAIL);
+    console.trace(e);
+    console.log(`Execution of job <${job.uri}> failed: ${e.message}`);
+    await updateJobStatus(job.uri, JOB.STATUSES.FAILED, e.message);
   }
 }
 

--- a/queries/delta.js
+++ b/queries/delta.js
@@ -1,11 +1,12 @@
 import { sparqlEscapeUri } from 'mu';
 import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
 import { parseSparqlResults } from './util';
+import { JOB } from '../config';
 
 const WHERE_TEMPLATE = `
 WHERE {
     GRAPH ?g {
-        ?job a ext:FileBundlingJob ;
+        ?job a ${sparqlEscapeUri(JOB.RDF_TYPE)} ;
             prov:used ?collection .
         ?collection a prov:Collection ;
             prov:hadMember #FILE_URI_PLACEHOLDER# .
@@ -41,7 +42,7 @@ async function findJobsWithoutCollectionMembers () {
 
   SELECT DISTINCT ?job ?collection ?file ?physf WHERE {
       GRAPH ?g {
-          ?job a ext:FileBundlingJob ;
+          ?job a ${sparqlEscapeUri(JOB.RDF_TYPE)} ;
               prov:used ?collection .
           ?collection a prov:Collection .
           ?job prov:generated ?file .
@@ -81,7 +82,7 @@ async function removePhysicalFilesOfJob (jobUri) {
   }
   WHERE {
     GRAPH ?g {
-      ${sparqlEscapeUri(jobUri)} a ext:FileBundlingJob ;
+      ${sparqlEscapeUri(jobUri)} a ${sparqlEscapeUri(JOB.RDF_TYPE)} ;
           prov:generated ?file .
       ?physf a nfo:FileDataObject ;
           nie:dataSource ?file ;
@@ -105,7 +106,7 @@ async function removeVirtualFilesOfJob (jobUri) {
   }
   WHERE {
     GRAPH ?g {
-      ${sparqlEscapeUri(jobUri)} a ext:FileBundlingJob ;
+      ${sparqlEscapeUri(jobUri)} a ${sparqlEscapeUri(JOB.RDF_TYPE)} ;
           prov:generated ?file .
       ?file a nfo:FileDataObject ;
           ?virtfP ?virtfO .
@@ -126,7 +127,7 @@ async function removeCollectionsOfJob (jobUri) {
   }
   WHERE {
     GRAPH ?g {
-      ${sparqlEscapeUri(jobUri)} a ext:FileBundlingJob ;
+      ${sparqlEscapeUri(jobUri)} a ${sparqlEscapeUri(JOB.RDF_TYPE)} ;
             prov:used ?collection .
         ?collection a prov:Collection ;
             ?collectionP ?collectionO .
@@ -146,7 +147,7 @@ async function removeJob (jobUri) {
   }
   WHERE {
       GRAPH ?g {
-          ${sparqlEscapeUri(jobUri)} a ext:FileBundlingJob ;
+          ${sparqlEscapeUri(jobUri)} a ${sparqlEscapeUri(JOB.RDF_TYPE)} ;
               ?jobP ?jobO .
       }
   }`

--- a/queries/job.js
+++ b/queries/job.js
@@ -1,29 +1,26 @@
 import { query, update, uuid as generateUuid, sparqlEscapeString, sparqlEscapeUri, sparqlEscapeDateTime } from 'mu';
 import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
-import { RESOURCE_BASE, RDF_JOB_TYPE } from '../config';
+import { RESOURCE_BASE, JOB } from '../config';
 import { parseSparqlResults, sparqlQueryWithRetry } from './util';
-
-// const SCHEDULED = 'scheduled';
-const RUNNING = 'http://vocab.deri.ie/cogs#Running';
-const SUCCESS = 'http://vocab.deri.ie/cogs#Success';
-const FAIL = 'http://vocab.deri.ie/cogs#Fail';
 
 async function createJob () {
   const uuid = generateUuid();
   const job = {
-    uri: RESOURCE_BASE + `/file-bundling-jobs/${uuid}`,
+    uri: RESOURCE_BASE + `/${JOB.JSONAPI_JOB_TYPE}/${uuid}`,
     id: uuid,
+    status: JOB.STATUSES.BUSY,
     created: new Date()
   };
   const queryString = `
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   PREFIX dct: <http://purl.org/dc/terms/>
   PREFIX cogs: <http://vocab.deri.ie/cogs#>
+  PREFIX adms: <http://www.w3.org/ns/adms#>
 
   INSERT DATA {
-      ${sparqlEscapeUri(job.uri)} a cogs:Job , ${sparqlEscapeUri(RDF_JOB_TYPE)} ;
+      ${sparqlEscapeUri(job.uri)} a cogs:Job , ${sparqlEscapeUri(JOB.RDF_TYPE)} ;
           mu:uuid ${sparqlEscapeString(job.id)} ;
+          adms:status ${sparqlEscapeUri(job.status)} ;
           dct:created ${sparqlEscapeDateTime(job.created)} .
   }`;
   await update(queryString); // NO SUDO
@@ -39,7 +36,7 @@ async function attachCollectionToJob (job, collection) {
       ${sparqlEscapeUri(job)} prov:used ${sparqlEscapeUri(collection)} .
   }
   WHERE {
-      ${sparqlEscapeUri(job)} a ${sparqlEscapeUri(RDF_JOB_TYPE)} .
+      ${sparqlEscapeUri(job)} a ${sparqlEscapeUri(JOB.RDF_TYPE)} .
       ${sparqlEscapeUri(collection)} a prov:Collection .
   }`;
   await update(queryString);
@@ -58,61 +55,71 @@ async function attachResultToJob (job, result) {
   }
   WHERE {
       GRAPH ?g {
-          ${sparqlEscapeUri(job)} a ${sparqlEscapeUri(RDF_JOB_TYPE)} .
+          ${sparqlEscapeUri(job)} a ${sparqlEscapeUri(JOB.RDF_TYPE)} .
       }
   }`;
   await updateSudo(queryString);
   return job;
 }
 
-async function updateJobStatus (uri, status) {
+async function updateJobStatus (uri, status, errorMessage) {
   const time = new Date();
   let timePred;
-  if (status === SUCCESS || status === FAIL) { // final statusses
+  if (status === JOB.STATUSES.SUCCESS || status === JOB.STATUSES.FAILED) { // final statusses
     timePred = 'http://www.w3.org/ns/prov#endedAtTime';
   } else {
     timePred = 'http://www.w3.org/ns/prov#startedAtTime';
   }
   const escapedUri = sparqlEscapeUri(uri);
   const queryString = `
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   PREFIX cogs: <http://vocab.deri.ie/cogs#>
+  PREFIX adms: <http://www.w3.org/ns/adms#>
+  PREFIX schema: <http://schema.org/>
 
   DELETE {
       GRAPH ?g {
-        ${escapedUri} ext:status ?status ;
-            ${sparqlEscapeUri(timePred)} ?time .
+          ${escapedUri} adms:status ?status ;
+              ${sparqlEscapeUri(timePred)} ?time .
       }
   }
   INSERT {
       GRAPH ?g {
-          ${escapedUri} ext:status ${sparqlEscapeUri(status)} ;
-              ${sparqlEscapeUri(timePred)} ${sparqlEscapeDateTime(time)} .
+          ${escapedUri} adms:status ${sparqlEscapeUri(status)} .
+          ${
+            status !== JOB.STATUSES.SCHEDULED
+              ? `${sparqlEscapeUri(uri)} ${sparqlEscapeUri(timePred)} ${sparqlEscapeDateTime(time)} .`
+              : ""
+          }
+          ${
+            errorMessage
+              ? `${sparqlEscapeUri(uri)} schema:error ${sparqlEscapeString(errorMessage)} .`
+              : ""
+          }
       }
   }
   WHERE {
       GRAPH ?g {
-          ${escapedUri} a ${sparqlEscapeUri(RDF_JOB_TYPE)} .
-          OPTIONAL { ${escapedUri} ext:status ?status }
+          ${escapedUri} a ${sparqlEscapeUri(JOB.RDF_TYPE)} .
+          OPTIONAL { ${escapedUri} adms:status ?status }
           OPTIONAL { ${escapedUri} ${sparqlEscapeUri(timePred)} ?time }
       }
   }`;
   await updateSudo(queryString);
 }
 
-async function findJobTodo (job) {
+async function findScheduledJob (job) {
   const queryString = `
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   PREFIX prov: <http://www.w3.org/ns/prov#>
+  PREFIX adms: <http://www.w3.org/ns/adms#>
 
   SELECT (?uuid as ?id) ?status ?used WHERE {
       GRAPH ?g {
-          ${sparqlEscapeUri(job)} a ${sparqlEscapeUri(RDF_JOB_TYPE)} ;
+          ${sparqlEscapeUri(job)} a ${sparqlEscapeUri(JOB.RDF_TYPE)} ;
               mu:uuid ?uuid .
           OPTIONAL { ${sparqlEscapeUri(job)} prov:used ?used . }
-          OPTIONAL { ${sparqlEscapeUri(job)} ext:status ?status . }
-          FILTER (?status NOT IN (${[RUNNING, SUCCESS, FAIL].map(sparqlEscapeUri).join(', ')}))
+          OPTIONAL { ${sparqlEscapeUri(job)} adms:status ?status . }
+          FILTER (?status = ${sparqlEscapeUri(JOB.STATUSES.SCHEDULED)})
       }
   }`;
   const results = await querySudo(queryString);
@@ -125,31 +132,34 @@ async function findJobTodo (job) {
   }
 }
 
+//
 async function findJobUsingCollection (collection) {
   const queryString = `
   PREFIX cogs: <http://vocab.deri.ie/cogs#>
   PREFIX prov: <http://www.w3.org/ns/prov#>
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   PREFIX dct: <http://purl.org/dc/terms/>
   PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  PREFIX adms: <http://www.w3.org/ns/adms#>
+  PREFIX schema: <http://schema.org/>
 
-  SELECT (?job AS ?uri) (?uuid as ?id) ?generated ?status ?created ?started ?ended WHERE {
+  SELECT (?job AS ?uri) (?uuid as ?id) ?generated ?status ?created ?started ?ended ?message WHERE {
       ${sparqlEscapeUri(collection)} a prov:Collection .
-      ?job a ${sparqlEscapeUri(RDF_JOB_TYPE)} ;
+      ?job a ${sparqlEscapeUri(JOB.RDF_TYPE)} ;
           mu:uuid ?uuid ;
-          ext:status ?status ;
+          adms:status ?status ;
           prov:generated ?generated ;
           prov:used ${sparqlEscapeUri(collection)} .
       VALUES ?status {
-        ${sparqlEscapeUri(SUCCESS)}
-        ${sparqlEscapeUri(RUNNING)}
+        ${sparqlEscapeUri(JOB.STATUSES.SUCCESS)}
+        ${sparqlEscapeUri(JOB.STATUSES.BUSY)}
       }
       ?generated a nfo:FileDataObject ;
           mu:uuid ?generatedId .
       OPTIONAL { ?job dct:created ?created }
       OPTIONAL { ?job prov:startedAtTime ?started }
       OPTIONAL { ?job prov:endedAtTime ?ended }
+      OPTIONAL { ?job schema:error ?message }
   }`;
   const results = await query(queryString); // NO SUDO!
   const parsedResults = parseSparqlResults(results);
@@ -165,13 +175,13 @@ async function findAllJobArchives () {
   PREFIX prov: <http://www.w3.org/ns/prov#>
   PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
   PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX adms: <http://www.w3.org/ns/adms#>
 
   SELECT DISTINCT ?job ?physf WHERE {
     GRAPH ?g {
-      ?job a ${sparqlEscapeUri(RDF_JOB_TYPE)} ;
+      ?job a ${sparqlEscapeUri(JOB.RDF_TYPE)} ;
           prov:generated ?file ;
-          ext:status ${sparqlEscapeUri(SUCCESS)} .
+          adms:status ${sparqlEscapeUri(JOB.STATUSES.SUCCESS)} .
       ?physf a nfo:FileDataObject ;
           nie:dataSource ?file .
     }
@@ -185,8 +195,7 @@ export {
   attachCollectionToJob,
   attachResultToJob,
   updateJobStatus,
-  RUNNING, SUCCESS, FAIL,
   findJobUsingCollection,
-  findJobTodo,
+  findScheduledJob,
   findAllJobArchives
 };


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4883

ext:status > adms:status
prov:startedAtTime and prov:endedAtTime
use redpencil statuses instead of cogs (cogs doesn't have "scheduled" status which is needed for some jobs)
move stuff to config
update readme
set message on fail


side tracking:
correct api response to match the model in resources